### PR TITLE
Add support for Splatoon byamls which do not have a path value table

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -76,8 +76,14 @@ namespace yamlconv
                 throw new InvalidDataException();
             if (offsets[2] > reader.BaseStream.Length)
                 throw new InvalidDataException();
-            if (offsets[3] > reader.BaseStream.Length)
-                throw new InvalidDataException();
+            if (offsets[3] > reader.BaseStream.Length) {
+                if (offsets[0] == 0x10) {
+                    offsets[3] = offsets[2]; // Splatoon byamls are missing offsets[2]
+                    offsets[2] = 0;
+                } else {
+                    throw new InvalidDataException();
+                }
+            }
 
             List<string> nodes = new List<string>();
             List<string> values = new List<string>();


### PR DESCRIPTION
Their header only have 3 ints, so if the fourth one is invalid, assume there is no path value table

(Also, offtopic, but: I find it amusing that you're converting BYAML to XML instead of regular YAML)
